### PR TITLE
Don't covert all property values to strings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ import {type VectorTileLayer, type VectorTile, VectorTileFeature} from '@mapbox/
 
 interface Context {
     keys: string[];
-    values: string[];
+    values: (string | boolean | number)[];
     keycache: Record<string, number>;
     valuecache: Record<string, number>;
     feature?: VectorTileFeature;
@@ -112,7 +112,7 @@ function writeProperties(context: Context, pbf: Pbf) {
         const valueKey = typeof value + ':' + value;
         let valueIndex = context.valuecache[valueKey];
         if (typeof valueIndex === 'undefined') {
-            context.values.push(value as string);
+            context.values.push(value);
             valueIndex = context.values.length - 1;
             context.valuecache[valueKey] = valueIndex;
         }

--- a/test/properties.js
+++ b/test/properties.js
@@ -34,7 +34,8 @@ describe('property encoding', function () {
           a: 'two',
           b: 2,
           c: { goodbye: 'planet' },
-          d: { hello: 'world' }
+          d: { hello: 'world' },
+          e: false
         },
         geometry: {
           type: 'Point',
@@ -52,11 +53,13 @@ describe('property encoding', function () {
 
     const first = layer.feature(0).properties
     const second = layer.feature(1).properties
-    expect(first.c).toEqual('{"hello":"world"}')
-    expect(first.d).toEqual('[1,2,3]')
-    expect(first.e).toEqual(undefined)
-    expect(second.c).toEqual('{"goodbye":"planet"}')
-    expect(second.d).toEqual('{"hello":"world"}')
+    expect(first.b).toStrictEqual(1)
+    expect(first.c).toStrictEqual('{"hello":"world"}')
+    expect(first.d).toStrictEqual('[1,2,3]')
+    expect(first.e).toStrictEqual(undefined)
+    expect(second.c).toStrictEqual('{"goodbye":"planet"}')
+    expect(second.d).toStrictEqual('{"hello":"world"}')
+    expect(second.e).toStrictEqual(false)
   })
 
   test('number encoding https://github.com/mapbox/vt-pbf/pull/11', function () {
@@ -121,7 +124,7 @@ test('id encoding', function () {
   const layer = vt.layers.geojsonLayer
   expect(layer.feature(0).id).toEqual(123)
   expect(layer.feature(1).id).toBeFalsy() // 'Non-integer values should not be saved'
-  expect(layer.feature(2).id).toBeFalsy()
+  expect(layer.feature(2).id).toBeUndefined()
 })
 
 test('accept geojson-vt options https://github.com/mapbox/vt-pbf/pull/21', function () {


### PR DESCRIPTION
Currently, all property values are converted to strings - even if they are otherwise allowable types. This PR removes this conversion, allowing all 3 supported types to be used and preserved.