### PR TITLE
Json prefix parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## main
 ### ✨ Features and improvements
+- Add ability to add a json prefix to json stringify results of nested objects in the mvt for later parsing ([#28](https://github.com/maplibre/vt-pbf/pull/28)) (by [HarelM](https://github.com/HarelM))
+
 - _...Add new stuff here..._
 
 ### 🐞 Bug fixes

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,8 @@ interface Context {
 /**
  * Serialize a vector-tile-js-created tile to pbf
  *
- * @param tile
+ * @param tile - the tile to serialize
+ * @param jsonPrefix - a string prefix to prepend to JSON-stringified non-primitive property values, used to distinguish them from regular string values when parsing the tile later. Default is "".
  * @return uncompressed, pbf-serialized tile data
  */
 export function fromVectorTileJs(tile: VectorTileLike, jsonPrefix = ""): Uint8Array {

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import type {GeoJSONVTTile} from '@maplibre/geojson-vt';
 import type {VectorTileFeatureLike, VectorTileLike, VectorTileLayerLike} from './lib/types';
 
 interface Context {
+    jsonPrefix: string;
     keys: string[];
     values: (string | boolean | number)[];
     keycache: Record<string, number>;
@@ -17,9 +18,9 @@ interface Context {
  * @param tile
  * @return uncompressed, pbf-serialized tile data
  */
-export function fromVectorTileJs(tile: VectorTileLike): Uint8Array {
+export function fromVectorTileJs(tile: VectorTileLike, jsonPrefix = ""): Uint8Array {
     const out = new Pbf();
-    writeTile(tile, out);
+    writeTile(tile, out, jsonPrefix);
     return out.finish();
 }
 
@@ -42,18 +43,19 @@ export function fromGeojsonVt(layers: Record<string, GeoJSONVTTile>, options?: G
     return fromVectorTileJs({ layers: l });
 }
 
-function writeTile(tile: VectorTileLike, pbf: Pbf) {
+function writeTile(tile: VectorTileLike, pbf: Pbf, jsonPrefix = "") {
     for (const key in tile.layers) {
-        pbf.writeMessage(3, writeLayer, tile.layers[key]);
+        pbf.writeMessage(3, (layer, pbf) => writeLayer(layer, pbf, jsonPrefix), tile.layers[key]);
     }
 }
 
-function writeLayer(layer: VectorTileLayerLike, pbf: Pbf) {
+function writeLayer(layer: VectorTileLayerLike, pbf: Pbf, jsonPrefix = "") {
     pbf.writeVarintField(15, layer.version || 1);
     pbf.writeStringField(1, layer.name || '');
     pbf.writeVarintField(5, layer.extent || 4096);
 
     const context: Context = {
+        jsonPrefix,
         keys: [],
         values: [],
         keycache: {},
@@ -107,7 +109,7 @@ function writeProperties(context: Context, pbf: Pbf) {
         pbf.writeVarint(keyIndex);
 
         if (typeof value !== 'string' && typeof value !== 'boolean' && typeof value !== 'number') {
-            value = JSON.stringify(value);
+            value = context.jsonPrefix + JSON.stringify(value);
         }
         const valueKey = typeof value + ':' + value;
         let valueIndex = context.valuecache[valueKey];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,6 +1569,7 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1642,6 +1643,7 @@
       "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -2041,6 +2043,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2429,7 +2432,6 @@
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -3198,6 +3200,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3254,7 +3257,6 @@
       "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "semver": "^7.5.4"
       },
@@ -3271,7 +3273,6 @@
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3412,7 +3413,6 @@
         "https://opencollective.com/eslint"
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.1.2",
         "@eslint-community/regexpp": "^4.11.0",
@@ -3431,6 +3431,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3475,7 +3476,6 @@
       "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
@@ -3505,7 +3505,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3522,7 +3521,6 @@
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3536,7 +3534,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3569,6 +3566,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -3585,6 +3583,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -4412,7 +4411,6 @@
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -4801,7 +4799,6 @@
       "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtin-modules": "^3.3.0"
       },
@@ -6438,7 +6435,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -6467,6 +6463,7 @@
       "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7473,7 +7470,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7635,6 +7633,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7750,6 +7749,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -7868,6 +7868,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -9079,6 +9080,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.9.tgz",
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~7.16.0"
       }
@@ -9133,6 +9135,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
       "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -9367,7 +9370,8 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9642,8 +9646,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "builtins": {
       "version": "5.1.0",
@@ -10180,6 +10183,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10341,7 +10345,6 @@
       "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
       "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
       "dev": true,
-      "peer": true,
       "requires": {
         "semver": "^7.5.4"
       },
@@ -10350,8 +10353,7 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
           "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -10424,7 +10426,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
       "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.1.2",
         "@eslint-community/regexpp": "^4.11.0",
@@ -10436,6 +10437,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -10474,7 +10476,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
       "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "builtins": "^5.0.1",
@@ -10494,7 +10495,6 @@
           "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
           "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
           "dev": true,
-          "peer": true,
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -10503,15 +10503,13 @@
           "version": "7.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
           "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-          "dev": true,
-          "peer": true
+          "dev": true
         },
         "type-fest": {
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-          "dev": true,
-          "peer": true
+          "dev": true
         }
       }
     },
@@ -10532,6 +10530,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
+      "peer": true,
       "requires": {}
     },
     "eslint-plugin-react": {
@@ -10539,6 +10538,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -10956,7 +10956,6 @@
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "resolve-pkg-maps": "^1.0.0"
       }
@@ -11196,7 +11195,6 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
       "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "builtin-modules": "^3.3.0"
       }
@@ -12269,8 +12267,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "resolve-protobuf-schema": {
       "version": "2.1.0",
@@ -12289,6 +12286,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
       "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@rollup/rollup-android-arm-eabi": "4.44.1",
         "@rollup/rollup-android-arm64": "4.44.1",
@@ -12943,7 +12941,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -13052,7 +13051,8 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "typescript-eslint": {
       "version": "8.35.1",
@@ -13129,6 +13129,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
       "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13168,6 +13169,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/test/properties.ts
+++ b/test/properties.ts
@@ -5,12 +5,37 @@ import {VectorTile} from '@mapbox/vector-tile';
 import GeoJsonEquality from 'geojson-equality';
 import fs from 'fs';
 import path from 'path';
-import {fromGeojsonVt} from '../index';
+import {fromGeojsonVt, fromVectorTileJs, GEOJSON_TILE_LAYER_NAME, GeoJSONWrapper} from '../index';
 import {Feature, FeatureCollection} from 'geojson';
 
 const eq = new GeoJsonEquality({ precision: 1 });
 
 describe('property encoding', () => {
+  test('property encoding: JSON.stringify non-primitive values with prefix', () => {
+    const orig: GeoJSON.FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [{
+        type: 'Feature',
+        properties: {
+          obj: { hello: 'world' },
+        },
+        geometry: {
+          type: 'Point',
+          coordinates: [0, 0]
+        }
+      }]
+    };
+    const tileindex = geojsonvt(orig, {});
+    const tile = tileindex.getTile(1, 0, 0);
+    const buff = fromVectorTileJs(new GeoJSONWrapper(tile?.features!), '__json__:');
+    const vt = new VectorTile(new Pbf(buff));
+    const layer = vt.layers[GEOJSON_TILE_LAYER_NAME];
+    const properties = layer.feature(0).properties;
+    expect(properties.obj).toStrictEqual('__json__:{\"hello\":\"world\"}');
+    expect(JSON.parse(properties.obj.toString().replace('__json__:', ''))).toStrictEqual({hello: 'world'});
+  });
+
+
   test('property encoding: JSON.stringify non-primitive values', () => {
     // Includes two properties with a common non-primitive value for
     // https://github.com/mapbox/vt-pbf/issues/9
@@ -47,12 +72,8 @@ describe('property encoding', () => {
 
     const tileindex = geojsonvt(orig, {});
     const tile = tileindex.getTile(1, 0, 0);
-    expect(tile).toBeTruthy();
-    if (!tile) {
-      return;
-    }
     
-    const buff = fromGeojsonVt({ geojsonLayer: tile });
+    const buff = fromGeojsonVt({ geojsonLayer: tile! });
 
     const vt = new VectorTile(new Pbf(buff));
     const layer = vt.layers.geojsonLayer;

--- a/test/properties.ts
+++ b/test/properties.ts
@@ -10,6 +10,8 @@ import {Feature, FeatureCollection} from 'geojson';
 
 const eq = new GeoJsonEquality({ precision: 1 });
 
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 describe('property encoding', () => {
   test('property encoding: JSON.stringify non-primitive values with prefix', () => {
     const orig: GeoJSON.FeatureCollection = {
@@ -26,12 +28,12 @@ describe('property encoding', () => {
       }]
     };
     const tileindex = geojsonvt(orig, {});
-    const tile = tileindex.getTile(1, 0, 0);
-    const buff = fromVectorTileJs(new GeoJSONWrapper(tile?.features!), '__json__:');
+    const tile = tileindex.getTile(1, 0, 0)!;
+    const buff = fromVectorTileJs(new GeoJSONWrapper(tile.features), '__json__:');
     const vt = new VectorTile(new Pbf(buff));
     const layer = vt.layers[GEOJSON_TILE_LAYER_NAME];
     const properties = layer.feature(0).properties;
-    expect(properties.obj).toStrictEqual('__json__:{\"hello\":\"world\"}');
+    expect(properties.obj).toStrictEqual('__json__:{"hello":"world"}');
     expect(JSON.parse(properties.obj.toString().replace('__json__:', ''))).toStrictEqual({hello: 'world'});
   });
 
@@ -71,9 +73,10 @@ describe('property encoding', () => {
     };
 
     const tileindex = geojsonvt(orig, {});
-    const tile = tileindex.getTile(1, 0, 0);
+    const tile = tileindex.getTile(1, 0, 0)!;
+    expect(tile).toBeTruthy();
     
-    const buff = fromGeojsonVt({ geojsonLayer: tile! });
+    const buff = fromGeojsonVt({ geojsonLayer: tile });
 
     const vt = new VectorTile(new Pbf(buff));
     const layer = vt.layers.geojsonLayer;


### PR DESCRIPTION
This adds a json prefix option to allow parsing it back when needed.
Since objects are json.strigified, adding a prefix will allow finding where an object was stringified and parse it back to json.
This is a hack, but other alternatives are more complicated and I'm not sure are better.
In theory, when MLT will support nested properties we can remove this option.  